### PR TITLE
Add unit test for FEN castling bug

### DIFF
--- a/src/test/java/de/czempin/chess/eden/brain/PositionTest.java
+++ b/src/test/java/de/czempin/chess/eden/brain/PositionTest.java
@@ -1,0 +1,16 @@
+package de.czempin.chess.eden.brain;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class PositionTest {
+    @Test
+    public void parsesBlackLongCastlingFlag() {
+        String fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w q - 0 1";
+        Position p = new Position();
+        p.setFENPosition(fen);
+        assertTrue(p.getCastleLongBlack());
+        assertFalse(p.getCastleShortBlack());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit test covering black long castle FEN parsing

## Testing
- `javac -d build/classes @sources.txt`
- `javac -d build/test-classes -cp build/classes:/opt/gradle/lib/junit-4.13.2.jar @test-sources.txt`
- `java -cp build/classes:build/test-classes:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore de.czempin.chess.eden.brain.PositionTest`