### PR TITLE
Fix FEN parsing for black castling

### DIFF
--- a/src/de/czempin/chess/eden/brain/Position.java
+++ b/src/de/czempin/chess/eden/brain/Position.java
@@ -3297,7 +3297,7 @@ public class Position {
 		this.castleShortWhite = (fenCastling.indexOf('K') != -1);
 		this.castleLongWhite = (fenCastling.indexOf('Q') != -1);
 		this.castleShortBlack = (fenCastling.indexOf('k') != -1);
-		this.castleLongBlack = (fenCastling.indexOf('k') != -1);
+               this.castleLongBlack = (fenCastling.indexOf('q') != -1);
 		String fenEnPassant = fenFields[3];
 		if (fenEnPassant.equals("-")) {
 			this.enPassantSquare = 0;

--- a/src/test/java/de/czempin/chess/eden/brain/PositionTest.java
+++ b/src/test/java/de/czempin/chess/eden/brain/PositionTest.java
@@ -1,0 +1,16 @@
+package de.czempin.chess.eden.brain;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class PositionTest {
+    @Test
+    public void parsesBlackLongCastlingFlag() {
+        String fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w q - 0 1";
+        Position p = new Position();
+        p.setFENPosition(fen);
+        assertTrue(p.getCastleLongBlack());
+        assertFalse(p.getCastleShortBlack());
+    }
+}


### PR DESCRIPTION
## Summary
- correctly parse black long castling right from FEN

## Testing
- `java -cp build/classes:build/test-classes:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore de.czempin.chess.eden.brain.PositionTest`